### PR TITLE
Fix ART's link and filename

### DIFF
--- a/.ci/install_dependencies.sh
+++ b/.ci/install_dependencies.sh
@@ -64,8 +64,8 @@ pip3 install pysam==0.15.4
 
 #__________________________ ART _______________________________#
 cd $install_root
-wget -q https://www.niehs.nih.gov/research/resources/assets/docs/artbinmountrainier20160605linux64tgz.tgz
-tar xf artbinmountrainier20160605linux64tgz.tgz
+wget -q https://www.niehs.nih.gov/research/resources/assets/docs/artbinmountrainier2016.06.05linux64.tgz
+tar xf artbinmountrainier2016.06.05linux64.tgz
 cp -s art_bin_MountRainier/art_illumina .
 
 


### PR DESCRIPTION
In .ci/install_dependencies.sh, ART is pulled from 
https://www.niehs.nih.gov/research/resources/assets/docs/artbinmountrainier20160605linux64tgz.tgz , but that is currently a 404. It appears it has been moved to https://www.niehs.nih.gov/research/resources/assets/docs/artbinmountrainier2016.06.05linux64.tgz .

Only tested the two lines that I changed and ensured the line immediately under it is still valid (ie, art_bin_MountRainier/art_illumina still exists).